### PR TITLE
Remove trailing comma

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,7 @@ module.exports = {
   env: {
     browser: true,
     es6: true,
-    node: true,
+    node: true
   },
   extends: "eslint:recommended",
   globals: {


### PR DESCRIPTION
Remove trailing comma in `.eslintrc.js`.
Running eslint produces the following output.

```bash
$ eslint .eslintrc.js --ignore-pattern '!.eslintrc.js'

/lecture-frontend-dev-env/.eslintrc.js
  5:15  error  Delete `,`  prettier/prettier

✖ 1 problem (1 error, 0 warnings)
  1 error and 0 warnings potentially fixable with the `--fix` option.
```

Default option of `Trailing Commas` in `Prettier` is `none`.

See also
  - https://prettier.io/docs/en/options.html#trailing-commas